### PR TITLE
Fix: brackets, address scope; match process name

### DIFF
--- a/colourfiles/conf.ss
+++ b/colourfiles/conf.ss
@@ -1,6 +1,14 @@
-# Local Address:Port
-regexp=\s((?:\d+\.){3}\d+|\*|::1?|[\w\d\-\_\.]+):(\S+)\s+\s((?:\d+\.){3}\d+|\*|::1?|[\w\d\-\_\.]+):(\S+)
-colours=default,bright_green,bright_red,cyan,magenta
+# status
+regexp=\[.*\]
+colours=green
+=======
+# Local Address:Port   Peer Address:Port
+regexp=\s((?:\d+\.){3}\d+|\*|\[?::1?\]?|[\w\d\-\_\.]+)(%[\w\d]+)?:(\S+)\s+\s((?:\d+\.){3}\d+|\*|\[?::1?\]?|[\w\d\-\_\.]+):(\S+)
+colours=default,bright_green,blue,bright_red,cyan,magenta
+=======
+# process name
+regexp=\("([^"]+)",
+colours=blue
 =======
 # ipx hostname
 regexp=^IPX.*[\dABCDEF]+:[\dABCDEF]+
@@ -66,10 +74,6 @@ colours=green
 # status
 regexp=UNKNOWN
 colours=blink bold red
-=======
-# status
-regexp=\[.*\]
-colours=green
 =======
 # path
 regexp=(\@)[\dabcdef]+


### PR DESCRIPTION
Newer versions of ss have a slightly different output syntax: IPv6 addresses are put in brackets (like in URLs).
tcp   LISTEN  0       32                       [::1]:53              [::]:*   
Also, the addresses' scope may be in the output:
192.168.1.1%eth0:68           0.0.0.0:*   users:(("NetworkManager",pid=82,fd=6)) ino:661155 sk:272 <->

I had to move the "status" regex or it would overwrite IPv6 addresses.